### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,14 @@
         "branchTracking": true
       }
     },
-    "test": "./node_modules/.bin/mocha"
-  }
+    "test": "mocha"
+  },
+  "bugs": {
+    "url": "https://github.com/walmartlabs/alce/issues"
+  },
+  "homepage": "https://github.com/walmartlabs/alce#readme",
+  "directories": {
+    "test": "test"
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
Notices license was missing from https://www.npmjs.com/package/alce.

I just ran `npm init`. It tried to remove `blanket` from `scripts`, otherwise all I did was remove empty author and change license from ICS to MIT.